### PR TITLE
feat: implement WithLoadOptionsEnv option for dynamic engine selection

### DIFF
--- a/config.go
+++ b/config.go
@@ -2,12 +2,50 @@ package config
 
 import (
 	"encoding" // nolint
+	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"reflect"
 	"strings"
 	"sync"
 )
+
+type configLoadOptions struct {
+	Plain   []string `json:"plain"`
+	Secrets []string `json:"secrets"`
+}
+
+// buildEnginesFromOptions resolves a list of engine type tokens ("env", "yaml") against
+// a pool of already-registered engines, returning the ordered engine list to use.
+// For "env": uses registered *EnvEngine instances, or creates a new default EnvEngine if none found.
+// For "yaml": uses registered *YAMLEngine instances found in the pool.
+func buildEnginesFromOptions(options []string, registered []Engine) []Engine {
+	result := make([]Engine, 0, len(options))
+	for _, opt := range options {
+		switch opt {
+		case "env":
+			var found bool
+			for _, eng := range registered {
+				if _, ok := eng.(*EnvEngine); ok {
+					result = append(result, eng)
+					found = true
+				}
+			}
+			if !found {
+				eng := NewEnvEngine()
+				result = append(result, &eng)
+			}
+		case "yaml":
+			for _, eng := range registered {
+				if _, ok := eng.(*YAMLEngine); ok {
+					result = append(result, eng)
+				}
+			}
+		}
+	}
+	return result
+}
 
 const (
 	defaultKeySeparator = "."
@@ -18,18 +56,33 @@ type Validator interface {
 }
 
 type Manager struct {
-	init         sync.Once
-	keySeparator *string
-	secrets      []Engine
-	plains       []Engine
+	init           sync.Once
+	keySeparator   *string
+	secrets        []Engine
+	plains         []Engine
+	loadOptionsEnv string
+	loadOptions    *configLoadOptions
+	loadOptionsErr error
 }
 
 type Option func(*Manager)
 
 func NewManager(opts ...Option) *Manager {
-	r := &Manager{}
+	r := &Manager{
+		loadOptionsEnv: "CONFIG_LOAD_OPTIONS",
+	}
 	for _, opt := range opts {
 		opt(r)
+	}
+	if r.loadOptionsEnv != "" {
+		if raw, ok := os.LookupEnv(r.loadOptionsEnv); ok && raw != "" {
+			var parsed configLoadOptions
+			if err := json.Unmarshal([]byte(raw), &parsed); err != nil {
+				r.loadOptionsErr = fmt.Errorf("parsing %s: %w", r.loadOptionsEnv, err)
+			} else {
+				r.loadOptions = &parsed
+			}
+		}
 	}
 	return r
 }
@@ -38,6 +91,14 @@ func NewManager(opts ...Option) *Manager {
 func WithKeySeparator(separator string) Option {
 	return func(m *Manager) {
 		m.keySeparator = &separator
+	}
+}
+
+// WithLoadOptionsEnv sets the name of the environment variable from which the manager will read
+// load options (JSON) at creation time. If envName is empty, this feature is disabled.
+func WithLoadOptionsEnv(envName string) Option {
+	return func(m *Manager) {
+		m.loadOptionsEnv = envName
 	}
 }
 
@@ -61,15 +122,26 @@ func (m *Manager) AddPlainEngine(engines ...Engine) {
 }
 
 func (m *Manager) Populate(cfg interface{}) error {
+	if m.loadOptionsErr != nil {
+		return m.loadOptionsErr
+	}
+
+	if m.loadOptions != nil {
+		if m.loadOptions.Plain != nil {
+			m.plains = buildEnginesFromOptions(m.loadOptions.Plain, m.plains)
+		}
+		if m.loadOptions.Secrets != nil {
+			m.secrets = buildEnginesFromOptions(m.loadOptions.Secrets, m.secrets)
+		}
+	}
+
 	for _, eng := range m.plains {
-		err := eng.Load()
-		if err != nil {
+		if err := eng.Load(); err != nil {
 			return err
 		}
 	}
 	for _, eng := range m.secrets {
-		err := eng.Load()
-		if err != nil {
+		if err := eng.Load(); err != nil {
 			return err
 		}
 	}

--- a/config_test.go
+++ b/config_test.go
@@ -4,6 +4,7 @@ package config
 
 import (
 	"fmt"
+	"os"
 	"testing"
 	"time"
 
@@ -11,6 +12,102 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func newTestYAMLEngine() *YAMLEngine {
+	return NewYAMLEngine(NewBytesLoader([]byte("dsn: from-yaml\npassword: yaml-pass")))
+}
+
+func TestWithLoadOptionsEnv(t *testing.T) {
+	t.Run("when env var is not set, uses registered engines as-is", func(t *testing.T) {
+		m := NewManager(WithLoadOptionsEnv("CONFIG_LOAD_OPTIONS_TEST"))
+		m.AddPlainEngine(newTestYAMLEngine())
+		m.AddSecretEngine(newTestYAMLEngine())
+		var cfg MyTestConfig
+		require.NoError(t, m.Populate(&cfg))
+		assert.Equal(t, "from-yaml", cfg.DSN)
+	})
+
+	t.Run("when env var is set with invalid JSON, Populate returns error", func(t *testing.T) {
+		os.Setenv("CONFIG_LOAD_OPTIONS_TEST", "not-json")
+		defer os.Unsetenv("CONFIG_LOAD_OPTIONS_TEST")
+
+		m := NewManager(WithLoadOptionsEnv("CONFIG_LOAD_OPTIONS_TEST"))
+		var cfg MyTestConfig
+		err := m.Populate(&cfg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "CONFIG_LOAD_OPTIONS_TEST")
+	})
+
+	t.Run("when plain is overridden to env, reads from environment variables", func(t *testing.T) {
+		withEnvironment(map[string]string{
+			"DSN":      "from-env",
+			"PASSWORD": "env-pass",
+		}, func() {
+			os.Setenv("CONFIG_LOAD_OPTIONS_TEST", `{"plain":["env"],"secrets":["env"]}`)
+			defer os.Unsetenv("CONFIG_LOAD_OPTIONS_TEST")
+
+			envEngine := NewEnvEngine()
+			m := NewManager(WithLoadOptionsEnv("CONFIG_LOAD_OPTIONS_TEST"))
+			m.AddPlainEngine(&envEngine)
+			m.AddSecretEngine(&envEngine)
+
+			var cfg MyTestConfig
+			require.NoError(t, m.Populate(&cfg))
+			assert.Equal(t, "from-env", cfg.DSN)
+		})
+	})
+
+	t.Run("when plain is overridden to yaml, uses the registered YAMLEngine", func(t *testing.T) {
+		withEnvironment(map[string]string{
+			"DSN":      "from-env",
+			"PASSWORD": "env-pass",
+		}, func() {
+			os.Setenv("CONFIG_LOAD_OPTIONS_TEST", `{"plain":["yaml"],"secrets":["env"]}`)
+			defer os.Unsetenv("CONFIG_LOAD_OPTIONS_TEST")
+
+			envEngine := NewEnvEngine()
+			m := NewManager(WithLoadOptionsEnv("CONFIG_LOAD_OPTIONS_TEST"))
+			m.AddPlainEngine(newTestYAMLEngine())
+			m.AddSecretEngine(&envEngine)
+
+			var cfg MyTestConfig
+			require.NoError(t, m.Populate(&cfg))
+			assert.Equal(t, "from-yaml", cfg.DSN)
+			assert.Equal(t, "env-pass", cfg.Password)
+		})
+	})
+
+	t.Run("when env token has no registered EnvEngine, creates a default one", func(t *testing.T) {
+		withEnvironment(map[string]string{
+			"DSN":      "from-env-default",
+			"PASSWORD": "env-pass-default",
+		}, func() {
+			os.Setenv("CONFIG_LOAD_OPTIONS_TEST", `{"plain":["env"],"secrets":["env"]}`)
+			defer os.Unsetenv("CONFIG_LOAD_OPTIONS_TEST")
+
+			m := NewManager(WithLoadOptionsEnv("CONFIG_LOAD_OPTIONS_TEST"))
+			m.AddPlainEngine(newTestYAMLEngine())
+			m.AddSecretEngine(newTestYAMLEngine())
+
+			var cfg MyTestConfig
+			require.NoError(t, m.Populate(&cfg))
+			assert.Equal(t, "from-env-default", cfg.DSN)
+		})
+	})
+
+	t.Run("when loadOptionsEnv is empty, feature is disabled", func(t *testing.T) {
+		os.Setenv("CONFIG_LOAD_OPTIONS_TEST", `{"plain":["env"]}`)
+		defer os.Unsetenv("CONFIG_LOAD_OPTIONS_TEST")
+
+		m := NewManager() // no WithLoadOptionsEnv
+		m.AddPlainEngine(newTestYAMLEngine())
+		m.AddSecretEngine(newTestYAMLEngine())
+
+		var cfg MyTestConfig
+		require.NoError(t, m.Populate(&cfg))
+		assert.Equal(t, "from-yaml", cfg.DSN)
+	})
+}
 
 func TestWithKeySeparator(t *testing.T) {
 	wantKeySeparator := "."


### PR DESCRIPTION
## Summary

- Adds `WithLoadOptionsEnv(envName string)` option to `Manager` — if `envName` is empty the feature is disabled
- At `NewManager` time, if the env var is set, its JSON value is parsed into `{"plain": [...], "secrets": [...]}` and stored on the manager; parse errors surface at `Populate` time
- At `Populate` time, the stored options rebuild `m.plains`/`m.secrets` by resolving `"env"` (uses registered `*EnvEngine`, or creates a default one if none registered) and `"yaml"` (uses registered `*YAMLEngine` instances) tokens