### PR TITLE
fix: buildEnginesFromOptions always creates new engines, adds yamlfile/yamlfileenv tokens

### DIFF
--- a/config.go
+++ b/config.go
@@ -16,35 +16,32 @@ type configLoadOptions struct {
 	Secrets []string `json:"secrets"`
 }
 
-// buildEnginesFromOptions resolves a list of engine type tokens ("env", "yaml") against
-// a pool of already-registered engines, returning the ordered engine list to use.
-// For "env": uses registered *EnvEngine instances, or creates a new default EnvEngine if none found.
-// For "yaml": uses registered *YAMLEngine instances found in the pool.
-func buildEnginesFromOptions(options []string, registered []Engine) []Engine {
+// buildEnginesFromOptions builds a list of engines from a list of token strings.
+//
+// Supported tokens:
+//   - "env": creates a new EnvEngine.
+//   - "yamlfile:<filepath>": creates a new YAMLEngine backed by the given file path.
+//   - "yamlfileenv:<ENV>": creates a new YAMLEngine backed by the file path read from the named env var.
+func buildEnginesFromOptions(options []string) ([]Engine, error) {
 	result := make([]Engine, 0, len(options))
 	for _, opt := range options {
-		switch opt {
-		case "env":
-			var found bool
-			for _, eng := range registered {
-				if _, ok := eng.(*EnvEngine); ok {
-					result = append(result, eng)
-					found = true
-				}
+		switch {
+		case opt == "env":
+			eng := NewEnvEngine()
+			result = append(result, &eng)
+		case strings.HasPrefix(opt, "yamlfile:"):
+			filePath := strings.TrimPrefix(opt, "yamlfile:")
+			result = append(result, NewYAMLEngine(NewFileLoader(filePath)))
+		case strings.HasPrefix(opt, "yamlfileenv:"):
+			envName := strings.TrimPrefix(opt, "yamlfileenv:")
+			filePath, ok := os.LookupEnv(envName)
+			if !ok || filePath == "" {
+				return nil, fmt.Errorf("yamlfileenv: environment variable %q is not set", envName)
 			}
-			if !found {
-				eng := NewEnvEngine()
-				result = append(result, &eng)
-			}
-		case "yaml":
-			for _, eng := range registered {
-				if _, ok := eng.(*YAMLEngine); ok {
-					result = append(result, eng)
-				}
-			}
+			result = append(result, NewYAMLEngine(NewFileLoader(filePath)))
 		}
 	}
-	return result
+	return result, nil
 }
 
 const (
@@ -128,10 +125,18 @@ func (m *Manager) Populate(cfg interface{}) error {
 
 	if m.loadOptions != nil {
 		if m.loadOptions.Plain != nil {
-			m.plains = buildEnginesFromOptions(m.loadOptions.Plain, m.plains)
+			plains, err := buildEnginesFromOptions(m.loadOptions.Plain)
+			if err != nil {
+				return err
+			}
+			m.plains = plains
 		}
 		if m.loadOptions.Secrets != nil {
-			m.secrets = buildEnginesFromOptions(m.loadOptions.Secrets, m.secrets)
+			secrets, err := buildEnginesFromOptions(m.loadOptions.Secrets)
+			if err != nil {
+				return err
+			}
+			m.secrets = secrets
 		}
 	}
 

--- a/config_test.go
+++ b/config_test.go
@@ -46,10 +46,7 @@ func TestWithLoadOptionsEnv(t *testing.T) {
 			os.Setenv("CONFIG_LOAD_OPTIONS_TEST", `{"plain":["env"],"secrets":["env"]}`)
 			defer os.Unsetenv("CONFIG_LOAD_OPTIONS_TEST")
 
-			envEngine := NewEnvEngine()
 			m := NewManager(WithLoadOptionsEnv("CONFIG_LOAD_OPTIONS_TEST"))
-			m.AddPlainEngine(&envEngine)
-			m.AddSecretEngine(&envEngine)
 
 			var cfg MyTestConfig
 			require.NoError(t, m.Populate(&cfg))
@@ -57,18 +54,15 @@ func TestWithLoadOptionsEnv(t *testing.T) {
 		})
 	})
 
-	t.Run("when plain is overridden to yaml, uses the registered YAMLEngine", func(t *testing.T) {
+	t.Run("when plain is overridden to yamlfile, reads from the given file", func(t *testing.T) {
 		withEnvironment(map[string]string{
 			"DSN":      "from-env",
 			"PASSWORD": "env-pass",
 		}, func() {
-			os.Setenv("CONFIG_LOAD_OPTIONS_TEST", `{"plain":["yaml"],"secrets":["env"]}`)
+			os.Setenv("CONFIG_LOAD_OPTIONS_TEST", `{"plain":["yamlfile:testdata/config_simple.yaml"],"secrets":["env"]}`)
 			defer os.Unsetenv("CONFIG_LOAD_OPTIONS_TEST")
 
-			envEngine := NewEnvEngine()
 			m := NewManager(WithLoadOptionsEnv("CONFIG_LOAD_OPTIONS_TEST"))
-			m.AddPlainEngine(newTestYAMLEngine())
-			m.AddSecretEngine(&envEngine)
 
 			var cfg MyTestConfig
 			require.NoError(t, m.Populate(&cfg))
@@ -77,22 +71,33 @@ func TestWithLoadOptionsEnv(t *testing.T) {
 		})
 	})
 
-	t.Run("when env token has no registered EnvEngine, creates a default one", func(t *testing.T) {
+	t.Run("when plain is overridden to yamlfileenv, reads file path from env var", func(t *testing.T) {
 		withEnvironment(map[string]string{
-			"DSN":      "from-env-default",
-			"PASSWORD": "env-pass-default",
+			"PASSWORD":        "env-pass",
+			"YAML_CONFIG_PATH": "testdata/config_simple.yaml",
 		}, func() {
-			os.Setenv("CONFIG_LOAD_OPTIONS_TEST", `{"plain":["env"],"secrets":["env"]}`)
+			os.Setenv("CONFIG_LOAD_OPTIONS_TEST", `{"plain":["yamlfileenv:YAML_CONFIG_PATH"],"secrets":["env"]}`)
 			defer os.Unsetenv("CONFIG_LOAD_OPTIONS_TEST")
 
 			m := NewManager(WithLoadOptionsEnv("CONFIG_LOAD_OPTIONS_TEST"))
-			m.AddPlainEngine(newTestYAMLEngine())
-			m.AddSecretEngine(newTestYAMLEngine())
 
 			var cfg MyTestConfig
 			require.NoError(t, m.Populate(&cfg))
-			assert.Equal(t, "from-env-default", cfg.DSN)
+			assert.Equal(t, "from-yaml", cfg.DSN)
+			assert.Equal(t, "env-pass", cfg.Password)
 		})
+	})
+
+	t.Run("when yamlfileenv references an unset env var, Populate returns error", func(t *testing.T) {
+		os.Setenv("CONFIG_LOAD_OPTIONS_TEST", `{"plain":["yamlfileenv:MISSING_VAR"]}`)
+		defer os.Unsetenv("CONFIG_LOAD_OPTIONS_TEST")
+
+		m := NewManager(WithLoadOptionsEnv("CONFIG_LOAD_OPTIONS_TEST"))
+
+		var cfg MyTestConfig
+		err := m.Populate(&cfg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "MISSING_VAR")
 	})
 
 	t.Run("when loadOptionsEnv is empty, feature is disabled", func(t *testing.T) {

--- a/testdata/config_simple.yaml
+++ b/testdata/config_simple.yaml
@@ -1,0 +1,2 @@
+dsn: from-yaml
+password: yaml-pass


### PR DESCRIPTION
## Summary

- Remove the `registered []Engine` parameter from `buildEnginesFromOptions` — engines are now always freshly created from tokens, never reused from the registered pool
- Add `yamlfile:<filepath>` token: creates a new `YAMLEngine` backed by a `FileLoader` pointing to the given path
- Add `yamlfileenv:<ENV>` token: reads the file path from the named environment variable and creates a new `YAMLEngine`; returns an error at `Populate` time if the variable is not set or empty
- Drop the `yaml` token (it required reusing registered engines, which is the pattern being removed)
- Update tests to use the new tokens and add `testdata/config_simple.yaml` fixture