### PR TITLE
feat: support map[K]Struct fields

### DIFF
--- a/config.go
+++ b/config.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"strconv"
 	"strings"
 	"sync"
 )
@@ -404,6 +405,10 @@ func (m *Manager) unmarshalObj(keyPrefix string, obj interface{}) error {
 			if err != nil {
 				return err
 			}
+		case fieldValue.Kind() == reflect.Map:
+			if err := m.unmarshalMap(key, fieldValue, isRequired); err != nil {
+				return err
+			}
 		}
 	}
 
@@ -414,6 +419,104 @@ func (m *Manager) unmarshalObj(keyPrefix string, obj interface{}) error {
 	}
 
 	return nil
+}
+
+func (m *Manager) unmarshalMap(prefix string, fieldValue reflect.Value, isRequired bool) error {
+	mapType := fieldValue.Type()
+	if mapType.Elem().Kind() != reflect.Struct {
+		return nil
+	}
+	indexes := m.collectMapIndexes(prefix)
+	if len(indexes) == 0 {
+		if isRequired {
+			return fmt.Errorf("%w: %s", ErrKeyNotFound, prefix)
+		}
+		return nil
+	}
+	keyType := mapType.Key()
+	elemType := mapType.Elem()
+	out := reflect.MakeMapWithSize(mapType, len(indexes))
+	for _, idx := range indexes {
+		mapKey, err := convertMapKey(keyType, idx)
+		if err != nil {
+			return fmt.Errorf("map %s: invalid key %q: %w", prefix, idx, err)
+		}
+		elem := reflect.New(elemType)
+		subKey := prefix + m.keySeparator + idx
+		if err := m.unmarshalObj(subKey, elem.Interface()); err != nil {
+			return err
+		}
+		out.SetMapIndex(mapKey, elem.Elem())
+	}
+	fieldValue.Set(out)
+	return nil
+}
+
+func (m *Manager) collectMapIndexes(prefix string) []string {
+	sep := m.keySeparator
+	full := prefix + sep
+	seen := make(map[string]struct{})
+	out := make([]string, 0)
+	collect := func(engines []Engine) {
+		for _, eng := range engines {
+			lister, ok := eng.(EngineKeyLister)
+			if !ok {
+				continue
+			}
+			for _, k := range lister.Keys() {
+				if !strings.HasPrefix(k, full) {
+					continue
+				}
+				rest := k[len(full):]
+				seg := rest
+				if i := strings.Index(rest, sep); i >= 0 {
+					seg = rest[:i]
+				}
+				if seg == "" {
+					continue
+				}
+				if _, ok := seen[seg]; ok {
+					continue
+				}
+				seen[seg] = struct{}{}
+				out = append(out, seg)
+			}
+		}
+	}
+	collect(m.plains)
+	collect(m.secrets)
+	return out
+}
+
+func convertMapKey(t reflect.Type, s string) (reflect.Value, error) {
+	ptr := reflect.New(t)
+	if u, ok := ptr.Interface().(encoding.TextUnmarshaler); ok {
+		if err := u.UnmarshalText([]byte(s)); err != nil {
+			return reflect.Value{}, err
+		}
+		return ptr.Elem(), nil
+	}
+	v := ptr.Elem()
+	switch t.Kind() {
+	case reflect.String:
+		v.SetString(s)
+		return v, nil
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		n, err := strconv.ParseInt(s, 10, t.Bits())
+		if err != nil {
+			return reflect.Value{}, err
+		}
+		v.SetInt(n)
+		return v, nil
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		n, err := strconv.ParseUint(s, 10, t.Bits())
+		if err != nil {
+			return reflect.Value{}, err
+		}
+		v.SetUint(n)
+		return v, nil
+	}
+	return reflect.Value{}, fmt.Errorf("unsupported map key type %s", t.String())
 }
 
 func readFromEnginesInSequence(engines []Engine, key string, isRequired bool, f func(engine Engine) error) error {

--- a/config_test.go
+++ b/config_test.go
@@ -5,6 +5,8 @@ package config
 import (
 	"fmt"
 	"os"
+	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -156,6 +158,68 @@ type MyTestConfigAllTypes struct {
 
 type MyTestConfigWithValidation struct {
 	N int `config:"n"`
+}
+
+type MyTestMapItem struct {
+	Name  string `config:"name"`
+	Value int    `config:"value"`
+}
+
+type MyTestMapItemRequired struct {
+	Name  string `config:"name,required"`
+	Value int    `config:"value"`
+}
+
+type MyTestMapItemWithSecret struct {
+	Name  string `config:"name"`
+	Token string `config:"token,secret"`
+}
+
+type MyTestConfigWithIntMap struct {
+	Items map[int]MyTestMapItem `config:"items"`
+}
+
+type MyTestConfigWithStringMap struct {
+	Items map[string]MyTestMapItem `config:"items"`
+}
+
+type MyTestConfigWithIntMapRequiredSub struct {
+	Items map[int]MyTestMapItemRequired `config:"items"`
+}
+
+type MyTestConfigWithIntMapSecret struct {
+	Items map[int]MyTestMapItemWithSecret `config:"items"`
+}
+
+type MyTestConfigWithInt64Map struct {
+	Items map[int64]MyTestMapItem `config:"items"`
+}
+
+type textKey struct {
+	Region string
+	ID     int
+}
+
+func (k *textKey) UnmarshalText(text []byte) error {
+	parts := strings.SplitN(string(text), "-", 2)
+	if len(parts) != 2 {
+		return fmt.Errorf("invalid textKey: %q", string(text))
+	}
+	id, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return err
+	}
+	k.Region = parts[0]
+	k.ID = id
+	return nil
+}
+
+type MyTestConfigWithTextKeyMap struct {
+	Items map[textKey]MyTestMapItem `config:"items"`
+}
+
+type MyTestConfigWithFloatKeyMap struct {
+	Items map[float64]MyTestMapItem `config:"items"`
 }
 
 var (
@@ -395,6 +459,205 @@ func TestManager_Populate(t *testing.T) {
 			var cfg MyTestConfigWithValidation
 			err := manager.Populate(&cfg)
 			require.ErrorIs(t, err, errMustBePositive)
+		})
+	})
+
+	t.Run("map of struct", func(t *testing.T) {
+		t.Run("populates map[int]Struct from MapEngine", func(t *testing.T) {
+			manager := NewManager()
+			mapEngine := NewMapEngine(map[string]interface{}{
+				"items": map[string]interface{}{
+					"1": map[string]interface{}{
+						"name":  "alpha",
+						"value": 10,
+					},
+					"2": map[string]interface{}{
+						"name":  "beta",
+						"value": 20,
+					},
+				},
+			})
+			manager.AddPlainEngine(mapEngine)
+			manager.AddSecretEngine(mapEngine)
+
+			var cfg MyTestConfigWithIntMap
+			err := manager.Populate(&cfg)
+			require.NoError(t, err)
+			assert.Len(t, cfg.Items, 2)
+			assert.Equal(t, "alpha", cfg.Items[1].Name)
+			assert.Equal(t, 10, cfg.Items[1].Value)
+			assert.Equal(t, "beta", cfg.Items[2].Name)
+			assert.Equal(t, 20, cfg.Items[2].Value)
+		})
+
+		t.Run("populates map[string]Struct from MapEngine", func(t *testing.T) {
+			manager := NewManager()
+			mapEngine := NewMapEngine(map[string]interface{}{
+				"items": map[string]interface{}{
+					"primary": map[string]interface{}{
+						"name":  "alpha",
+						"value": 10,
+					},
+					"secondary": map[string]interface{}{
+						"name":  "beta",
+						"value": 20,
+					},
+				},
+			})
+			manager.AddPlainEngine(mapEngine)
+			manager.AddSecretEngine(mapEngine)
+
+			var cfg MyTestConfigWithStringMap
+			err := manager.Populate(&cfg)
+			require.NoError(t, err)
+			assert.Len(t, cfg.Items, 2)
+			assert.Equal(t, "alpha", cfg.Items["primary"].Name)
+			assert.Equal(t, 10, cfg.Items["primary"].Value)
+			assert.Equal(t, "beta", cfg.Items["secondary"].Name)
+			assert.Equal(t, 20, cfg.Items["secondary"].Value)
+		})
+
+		t.Run("populates map[int64]Struct from MapEngine", func(t *testing.T) {
+			manager := NewManager()
+			mapEngine := NewMapEngine(map[string]interface{}{
+				"items": map[string]interface{}{
+					"100": map[string]interface{}{
+						"name":  "alpha",
+						"value": 10,
+					},
+				},
+			})
+			manager.AddPlainEngine(mapEngine)
+			manager.AddSecretEngine(mapEngine)
+
+			var cfg MyTestConfigWithInt64Map
+			err := manager.Populate(&cfg)
+			require.NoError(t, err)
+			assert.Len(t, cfg.Items, 1)
+			assert.Equal(t, "alpha", cfg.Items[100].Name)
+		})
+
+		t.Run("leaves map nil when no keys present", func(t *testing.T) {
+			manager := NewManager()
+			mapEngine := NewMapEngine(map[string]interface{}{
+				"unrelated": "value",
+			})
+			manager.AddPlainEngine(mapEngine)
+			manager.AddSecretEngine(mapEngine)
+
+			var cfg MyTestConfigWithIntMap
+			err := manager.Populate(&cfg)
+			require.NoError(t, err)
+			assert.Nil(t, cfg.Items)
+		})
+
+		t.Run("returns error when required subfield missing", func(t *testing.T) {
+			manager := NewManager()
+			mapEngine := NewMapEngine(map[string]interface{}{
+				"items": map[string]interface{}{
+					"1": map[string]interface{}{
+						"value": 10,
+					},
+				},
+			})
+			manager.AddPlainEngine(mapEngine)
+			manager.AddSecretEngine(mapEngine)
+
+			var cfg MyTestConfigWithIntMapRequiredSub
+			err := manager.Populate(&cfg)
+			require.ErrorIs(t, err, ErrKeyNotFound)
+		})
+
+		t.Run("routes secret subfield to secret engines", func(t *testing.T) {
+			manager := NewManager()
+			plain := NewMapEngine(map[string]interface{}{
+				"items": map[string]interface{}{
+					"1": map[string]interface{}{
+						"name": "alpha",
+					},
+				},
+			})
+			secret := NewMapEngine(map[string]interface{}{
+				"items": map[string]interface{}{
+					"1": map[string]interface{}{
+						"token": "s3cr3t",
+					},
+				},
+			})
+			manager.AddPlainEngine(plain)
+			manager.AddSecretEngine(secret)
+
+			var cfg MyTestConfigWithIntMapSecret
+			err := manager.Populate(&cfg)
+			require.NoError(t, err)
+			assert.Equal(t, "alpha", cfg.Items[1].Name)
+			assert.Equal(t, "s3cr3t", cfg.Items[1].Token)
+		})
+
+		t.Run("populates map[int]Struct from YAMLEngine", func(t *testing.T) {
+			manager := NewManager()
+			yEngine := NewYAMLEngine(NewFileLoader("testdata/config_intmap.yaml"))
+			manager.AddPlainEngine(yEngine)
+			manager.AddSecretEngine(yEngine)
+
+			var cfg MyTestConfigWithIntMap
+			err := manager.Populate(&cfg)
+			require.NoError(t, err)
+			assert.Len(t, cfg.Items, 2)
+			assert.Equal(t, "alpha", cfg.Items[1].Name)
+			assert.Equal(t, 10, cfg.Items[1].Value)
+			assert.Equal(t, "beta", cfg.Items[2].Name)
+			assert.Equal(t, 20, cfg.Items[2].Value)
+		})
+
+		t.Run("populates map[string]Struct from YAMLEngine", func(t *testing.T) {
+			manager := NewManager()
+			yEngine := NewYAMLEngine(NewFileLoader("testdata/config_stringmap.yaml"))
+			manager.AddPlainEngine(yEngine)
+			manager.AddSecretEngine(yEngine)
+
+			var cfg MyTestConfigWithStringMap
+			err := manager.Populate(&cfg)
+			require.NoError(t, err)
+			assert.Len(t, cfg.Items, 2)
+			assert.Equal(t, "alpha", cfg.Items["primary"].Name)
+			assert.Equal(t, 10, cfg.Items["primary"].Value)
+			assert.Equal(t, "beta", cfg.Items["secondary"].Name)
+			assert.Equal(t, 20, cfg.Items["secondary"].Value)
+		})
+
+		t.Run("populates map with TextUnmarshaler key from YAMLEngine", func(t *testing.T) {
+			manager := NewManager()
+			yEngine := NewYAMLEngine(NewFileLoader("testdata/config_textkeymap.yaml"))
+			manager.AddPlainEngine(yEngine)
+			manager.AddSecretEngine(yEngine)
+
+			var cfg MyTestConfigWithTextKeyMap
+			err := manager.Populate(&cfg)
+			require.NoError(t, err)
+			assert.Len(t, cfg.Items, 2)
+			assert.Equal(t, "alpha", cfg.Items[textKey{Region: "us", ID: 1}].Name)
+			assert.Equal(t, 10, cfg.Items[textKey{Region: "us", ID: 1}].Value)
+			assert.Equal(t, "beta", cfg.Items[textKey{Region: "eu", ID: 2}].Name)
+			assert.Equal(t, 20, cfg.Items[textKey{Region: "eu", ID: 2}].Value)
+		})
+
+		t.Run("returns error when map key type unsupported and not TextUnmarshaler", func(t *testing.T) {
+			manager := NewManager()
+			mapEngine := NewMapEngine(map[string]interface{}{
+				"items": map[string]interface{}{
+					"1.5": map[string]interface{}{
+						"name": "alpha",
+					},
+				},
+			})
+			manager.AddPlainEngine(mapEngine)
+			manager.AddSecretEngine(mapEngine)
+
+			var cfg MyTestConfigWithFloatKeyMap
+			err := manager.Populate(&cfg)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "unsupported map key type")
 		})
 	})
 }

--- a/engine.go
+++ b/engine.go
@@ -31,3 +31,11 @@ type Engine interface {
 
 	GetDuration(key string) (time.Duration, error)
 }
+
+// EngineKeyLister is an optional capability for engines that can enumerate
+// their flat keys. Engines that implement this enable features that need to
+// discover structure from the underlying source, such as populating
+// map[K]Struct fields.
+type EngineKeyLister interface {
+	Keys() []string
+}

--- a/engine_map.go
+++ b/engine_map.go
@@ -24,6 +24,17 @@ func (engine *MapEngine) Unload() error {
 	return nil
 }
 
+func (engine *MapEngine) Keys() []string {
+	if engine.data == nil {
+		return nil
+	}
+	keys := make([]string, 0, len(engine.data))
+	for k := range engine.data {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
 func (engine *MapEngine) GetString(key string) (string, error) {
 	if engine.data == nil {
 		return "", ErrEngineNotLoaded

--- a/testdata/config_intmap.yaml
+++ b/testdata/config_intmap.yaml
@@ -1,0 +1,7 @@
+items:
+  "1":
+    name: "alpha"
+    value: 10
+  "2":
+    name: "beta"
+    value: 20

--- a/testdata/config_stringmap.yaml
+++ b/testdata/config_stringmap.yaml
@@ -1,0 +1,7 @@
+items:
+  primary:
+    name: "alpha"
+    value: 10
+  secondary:
+    name: "beta"
+    value: 20

--- a/testdata/config_textkeymap.yaml
+++ b/testdata/config_textkeymap.yaml
@@ -1,0 +1,7 @@
+items:
+  us-1:
+    name: "alpha"
+    value: 10
+  eu-2:
+    name: "beta"
+    value: 20


### PR DESCRIPTION
Adds support for `map[K]Struct` config fields.

Engines opt in by implementing `EngineKeyLister` (added on `MapEngine`, inherited by `YAMLEngine`). Keys can be `string`, any `int`/`uint` kind, or any type implementing `encoding.TextUnmarshaler`.